### PR TITLE
bump Carpe-Hora/SmsSender version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "symfony/framework-bundle": ">=2.1.0",
         "psr/log": "~1.0",
-        "Carpe-Hora/SmsSender": "~1.2.0"
+        "Carpe-Hora/SmsSender": "~1.3.0"
     },
     "require-dev": {
         "symfony/symfony": ">=2.1.0",


### PR DESCRIPTION
I'm finally back at by pet project. It seems that SmsSender only contains the Swisscom provider after 1.3.

This sorts that out. Sorry for not having noticed earlier.
